### PR TITLE
fix incorrectly inheriting from Stream

### DIFF
--- a/clarinet.js
+++ b/clarinet.js
@@ -161,13 +161,12 @@ if(typeof FastList === 'function') {
   function CStream (opt) {
     if (!(this instanceof CStream)) return new CStream(opt);
 
-    Stream.apply(me);
-
     this._parser = new CParser(opt);
     this.writable = true;
     this.readable = true;
 
     var me = this;
+    Stream.apply(me);
 
     this._parser.onend = function () { me.emit("end"); };
     this._parser.onerror = function (er) {


### PR DESCRIPTION
mocha was giving me an error saying there were some global leaks. It turned out that `Stream.apply()` is called with an undefined context. Which then defaults to the global context, adding properties to it.
