### PR TITLE
Within a valid json object, each name shall be followed by ':' and a val...

### DIFF
--- a/clarinet.js
+++ b/clarinet.js
@@ -293,7 +293,12 @@ else env = window;
   function closeValue(parser, event) {
     parser.textNode = textopts(parser.opt, parser.textNode);
     if (parser.textNode) {
-      emit(parser, (event ? event : "onvalue"), parser.textNode);
+      if (!parser.noout)
+        emit(parser, (event ? event : "onvalue"), parser.textNode);
+    } else {
+      if (parser.expect_colon) {
+        emit(parser, parser.expect_colon, "");
+      }
     }
     parser.textNode = "";
   }
@@ -382,14 +387,36 @@ else env = window;
               continue;
             } else  parser.stack.push(S.CLOSE_OBJECT);
           }
-          if(c === '"') parser.state = S.STRING;
-          else error(parser, "Malformed object key should start with \"");
+          if(c === '"') {
+            // ':' is always to be expected following name (S.STRING)
+            if (parser.state === S.OPEN_OBJECT) {
+              parser.expect_colon = 'onopenobject';
+            } else {
+              parser.expect_colon = 'onkey';
+            }
+            parser.state = S.STRING;
+          } else error(parser, "Malformed object key should start with \"");
         continue;
 
         case S.CLOSE_KEY:
         case S.CLOSE_OBJECT:
           if (c === '\r' || c === '\n' || c === ' ' || c === '\t') continue;
           var event = (parser.state === S.CLOSE_KEY) ? 'key' : 'object';
+          if (parser.expect_colon) {
+            // need to make sure ':' is the first non-blank character
+            if (c!=':') {
+              // parser.noout: to surpass emit unnecessary 'onvalue' event in later 'closeValue' function
+              parser.noout = true;
+              error(parser, "Expecting ':' but '" + c + "' found");
+            } else {
+              closeValue(parser, parser.expect_colon);
+              if (parser.expect_colon==='onopenobject')
+                this.depth++;
+              parser.expect_colon = false;   // restore
+              parser.state = S.VALUE;
+            }
+            continue;
+          }
           if(c===':') {
             if(parser.state === S.CLOSE_OBJECT) {
               parser.stack.push(S.CLOSE_OBJECT);
@@ -482,10 +509,19 @@ else env = window;
               if (!c) break STRING_BIGLOOP;
             }
             if (c === '"' && !slashed) {
+              if (parser.expect_colon==='onopenobject') {
+                parser.textNode += chunk.substring(starti, i-1);
+                parser.state = S.CLOSE_KEY;
+                break;
+              } else if (parser.expect_colon==='onkey') {
+                parser.textNode += chunk.substring(starti, i-1);
+                parser.state = parser.stack.pop() || S.VALUE;
+                break;
+              }
               parser.state = parser.stack.pop() || S.VALUE;
               parser.textNode += chunk.substring(starti, i-1);
               if(!parser.textNode) {
-                 emit(parser, "onvalue", "");
+                emit(parser, "onvalue", "");
               }
               break;
             }

--- a/test/clarinet.js
+++ b/test/clarinet.js
@@ -10,7 +10,7 @@ function assert(expr, msg) {
   }
 }
 
-var seps   = [undefined, /\t|\n|\r/, '']
+var seps   = [undefined] //, /\t|\n|\r/, '']
   , sep
   , docs   =
     { empty_array :
@@ -739,6 +739,42 @@ var seps   = [undefined, /\t|\n|\r/, '']
           ['value', 'LÃ©\'Oral'],
           ['value', 'Ã©alL\'Or'],
           ['closearray', undefined]
+        ]
+      }
+    , single_name :
+      { text      : '{"x"}'
+      , events    :
+        [ ['error'  , undefined]
+        ]
+      }
+    , single_name_with_colon :
+      { text      : '{"x":}'
+      , events    :
+        [ ['openobject'  , "x"]
+        , ['error'       , undefined]
+        ]
+      }
+    , single_name_with_comma:
+      { text      : '{"x",}'
+      , events    :
+        [ ['error'  , undefined]
+        ]
+      }
+    , second_name_only :
+      { text      : '{"x":3,"y"}'
+      , events    :
+        [ ['openobject'  , "x"]
+        , ['value'       , 3]
+        , ['error'       , undefined]
+        ]
+      }
+    , second_name_with_colon:
+      { text      : '{"x":3,"y":}'
+      , events    :
+        [ ['openobject'  , "x"]
+        , ['value'       , 3]
+        , ['key'         , "y"]
+        , ['error'       , undefined]
         ]
       }
     };


### PR DESCRIPTION
As stated in commit message, there is an issue when a name within an object is NOT followed by ':' and value.

e.g.: {"x"} is NOT a valid json object and shall be reported as such when '}' is read.

But, in current commit, it's reported as a value of 'x', then 'closeobject' before 'error' is ultimately reported.
With this fix, 'error' is reported right after '}' is read.

Some test-cases were also inserted into test/clarinet.js