### PR TITLE
Add .npmignore to minimize package install size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+bench/
+samples/
+test/


### PR DESCRIPTION
When installing this module it's total size is about 38M:

```
376K    ./bench
 24M    ./samples
 13M    ./test
 38M    .
```

Though those files are not needed to be able to use the module. I suggest adding this `.npmignore` to minimize the package size on install.
I'm using this module inside a [`mhart/alpine-nodejs`](https://registry.hub.docker.com/u/mhart/alpine-node/) docker container at the moment and this module roughly doubles the total image size.

Thanks in advance!
