### PR TITLE
fix(keys): empty

### DIFF
--- a/test/clarinet.js
+++ b/test/clarinet.js
@@ -52,6 +52,18 @@ var seps   = [undefined, /\t|\n|\r/, '']
         , ['ready'       , undefined]
         ]
       }
+    , empty_key :
+      { text      : '{"foo": "bar", "": "baz"}'
+      , events    :
+        [ ["openobject"  , "foo"]
+        , ["value"       , "bar"]
+        , ["key"         , ""]
+        , ["value"       , "baz"]
+        , ["closeobject" , undefined]
+        , ['end'         , undefined]
+        , ['ready'       , undefined]
+        ]
+      }
     , three_byte_utf8 :
       { text          : '{"matzue": "松江", "asakusa": "浅草"}'
       , events        :


### PR DESCRIPTION
Fixed a bug where empty keys were not recognized. Undefined has replaced
the empty string as the default value for a text node so that empty keys
are now handled properly.

See #42 
