### PR TITLE
Make tests run on Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "underscore": "1.2.3"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha -r should -t 10000 -s 2000  test/clarinet.js test/npm.js test/utf8-chunks.js test/position.js"
+    "test": "mocha -r should -t 10000 -s 2000  test/clarinet.js test/npm.js test/utf8-chunks.js test/position.js"
   },
   "engines": {
     "node": ">=0.3.6",


### PR DESCRIPTION
npm run (npm test calls npm run test) automatically adds node_modules/.bin
to PATH. This way, you do not have to specify the path to node_modules/.bin.
On Windows, specifying a unix-style path results in an error, so omitting the
relative path enables mocha to be called successfully.