### PR TITLE
Add runkit example file

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,0 +1,23 @@
+var clarinet = require("clarinet")
+
+var parser = clarinet.parser();
+parser.onvalue = function (v) {
+  console.log("Value: " + v);
+};
+parser.onkey = function (key) {
+  console.log("Key: " + key);
+};
+parser.onopenobject = function () {
+    console.log("New Object");
+}
+parser.oncloseobject = function () {
+    console.log("Close Object");
+}
+parser.onopenarray = function () {
+    console.log("New Array");
+}
+parser.onclosearray = function () {
+    console.log("Close Array");
+}
+
+parser.write('{ "firstName": "John", "lastName" : "Smith", "age" : 25, "address" : { "streetAddress": "21 2nd Street", "city" : "New York", "state" : "NY", "postalCode" : "10021" }, "phoneNumber": [ { "type" : "home", "number": "212 555-1234" }, { "type" : "fax", "number": "646 555-4567" } ] }').close();

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "bugs": {
     "url": "http://github.com/dscape/clarinet/issues"
   },
+  "runkitExampleFilename": "example.js",
   "keywords": [
     "sax",
     "json",


### PR DESCRIPTION
Just to make it easier to get up running with clarinet and see how it works, I've added an example file and added the runkit config to `package.json` so from the npmjs page, someone can click on the "Test with Runkit" button and run the example code straight away.