### PR TITLE
Add --ignore-scripts for the benchmark install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "test": "mocha -r should -t 10000 -s 2000 test/parser.spec.js test/clarinet.js test/npm.js test/utf8-chunks.js test/position.js",
     "bench": "cd benchmark && npm test",
-    "postinstall": "cd benchmark && npm i"
+    "postinstall": "cd benchmark && npm i --ignore-scripts"
   },
   "engines": {
     "node": ">=0.3.6",


### PR DESCRIPTION
This will break the infinite loop of issue #58