### PR TITLE
Support Web Workers

### DIFF
--- a/clarinet.js
+++ b/clarinet.js
@@ -4,7 +4,7 @@
   // non node-js needs to set clarinet debug on root
   var env =(typeof process === 'object' && process.env)
     ? process.env
-    : window;
+    : self;
 
   clarinet.parser            = function (opt) { return new CParser(opt);};
   clarinet.CParser           = CParser;


### PR DESCRIPTION
window is not present in Web Workers, so even if process is undefined, window might not be.

I changed window to `self`, as it represents the window and is present in both workers and DOM.

Original issue: https://github.com/dfahlander/Dexie.js/issues/922