### PR TITLE
Upgrade mocha used by benchmark for security, bump package version

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clarinet-benchmark",
   "description": "Benchmark to measure clarinet.js vs. the last published version",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "main": "./index.js",
   "homepage": "https://github.com/dscape/clarinet",
   "private": true,
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "benchmark": "^2.1.4",
-    "mocha": "1.3.x"
+    "mocha": ">=6.2.2"
   },
   "scripts": {
     "test": "node index.js"


### PR DESCRIPTION
Upgrade Mocha version to latest in Clarinet's benchmark internal package, to pick up recent commits, including this set of security upgrades: https://github.com/mochajs/mocha/pull/3380

I also bumped the version of this clarinet-benchmark package, not sure if this is necessary though, let me know if there is a better way to do this. Thank you really appreciate it!