### PR TITLE
Exclusion of benchmark folder in published artifact

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 bench/
 samples/
 test/
+benchmark/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Roly Fentanes (http://about.me/roly)",
     "John Lancaster (http://jlank.com)"
   ],
-  "version": "0.12.4",
+  "version": "0.12.5",
   "main": "./clarinet.js",
   "homepage": "https://github.com/dscape/clarinet",
   "repository": {


### PR DESCRIPTION
Fixes #73: 
The following PR prevents `benchmark/` from being published. Inclusion of `node_modules` into the published image seems inadvertent while upgrading from `0.12.2` to `0.12.3` where the number of files in artifact went up from `10` to `1222`.
Excluding the `benchmark/node_modules` is necessary to eliminate vulnerabilities in upstream packages caused by old versions of devDependencies (such as `lodash` and `growl` that are brought in via `mocha`: `1.3.x` ([ref.](https://github.com/dscape/clarinet/blob/master/benchmark/package.json#L17)) in `benchmark/node_modules`), but dependents of the `clarinet` package wouldn't use the `benchmarks` folder so I suggest excluding it while publishing the artifact.

<img width="1603" alt="clarinet-0 12 2" src="https://user-images.githubusercontent.com/88032205/148542581-c99f2098-d9d0-423e-9fb3-b6f33abbd300.png">
<img width="1610" alt="clarinet-0 12 3" src="https://user-images.githubusercontent.com/88032205/148542585-1077643a-4f96-4a90-990a-ba716fd37fcf.png">
